### PR TITLE
adding support for private ip + zones

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -46,9 +46,9 @@ steps:
             - DA_AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
-  - label: Terraform Apply and Destroy VPC
-    key: apply-destroy-vpc
-    command: .buildkite/scripts/apply.sh --TF_DIR examples/vpc --PREFIX rp-vpc
+  - label: Terraform Apply and Destroy Private VPC
+    key: apply-destroy-pvt-vpc
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/private-vpc --PREFIX rp-pvt-vpc
     plugins:
       - docker#v5.4.0:
           image: glrp/atgt:latest

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -56,3 +56,14 @@ steps:
             - DA_AWS_ACCESS_KEY_ID
             - DA_AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
+
+  - label: Terraform Apply and Destroy Private VPC No Zone
+    key: apply-destroy-pvt-vpc-no-zone
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/private-vpc-no-zone --PREFIX rp-pvt-nzone
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,58 @@
+agents:
+  queue: "k8s-builders"
+
+steps:
+  - label: Terraform Apply and Destroy Private
+    key: apply-destroy-private
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/private --PREFIX rp-private
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+
+  - label: Terraform Apply and Destroy VPC Public
+    key: apply-destroy-public-vpc
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/public-vpc --PREFIX rp-pub-vpc
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+
+  - label: Terraform Apply and Destroy Simple
+    key: apply-destroy-simple
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/simple --PREFIX rp-simple
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+
+  - label: Terraform Apply and Destroy Tiered Storage
+    key: apply-destroy-tiered-storage
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/tiered_storage --PREFIX rp-tiered-storage
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+
+  - label: Terraform Apply and Destroy VPC
+    key: apply-destroy-vpc
+    command: .buildkite/scripts/apply.sh --TF_DIR examples/vpc --PREFIX rp-vpc
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION

--- a/.buildkite/scripts/apply.sh
+++ b/.buildkite/scripts/apply.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+export AWS_ACCESS_KEY_ID=$DA_AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$DA_AWS_SECRET_ACCESS_KEY
+
+mkdir -p ~/.ssh
+ssh-keygen -t rsa -b 4096 -C "test@redpanda.com" -N "" -f ~/.ssh/id_rsa <<< y && chmod 0700 ~/.ssh/id_rsa
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --TF_DIR) TF_DIR="$2"; shift ;;
+        --PREFIX) PREFIX="$2"; shift ;;
+        --AWS_ACCESS_KEY_ID) AWS_ACCESS_KEY_ID="$2"; shift ;;
+        --AWS_SECRET_ACCESS_KEY) AWS_SECRET_ACCESS_KEY="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Check if TF_DIR and PREFIX are set
+if [ -z "$TF_DIR" ] || [ -z "$PREFIX" ] || [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "TF_DIR, PREFIX, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY must be set. Exiting."
+    exit 1
+fi
+
+cd "$TF_DIR" || exit 1
+terraform init || exit 1
+
+# Trap to handle terraform destroy on exit
+trap cleanup EXIT INT TERM
+cleanup() {
+    error_code=$?
+    terraform destroy --auto-approve
+    exit $error_code
+}
+
+terraform apply -var "deployment_prefix=$PREFIX" --auto-approve
+
+# Trap will handle destroy so just exit
+exit $?

--- a/README.md
+++ b/README.md
@@ -1,86 +1,89 @@
 # terraform-aws-redpanda-cluster
 
+[![Build status](https://badge.buildkite.com/474f20b5cae84a6213f822e1643d24e76a38d37229e461421b.svg)](https://buildkite.com/redpanda/terraform-aws-redpanda-cluster)
 
-This Terraform module will deploy VMs on AWS EC2, with a security group which allows inbound traffic on ports used by Redpanda and monitoring tools. Once deployed, you can use [our Ansible collection](https://github.com/redpanda-data/redpanda-ansible-collection) to build a [Redpanda Cluster](https://docs.redpanda.com/docs/home/). 
+This Terraform module will deploy VMs on AWS EC2, with a security group which allows inbound traffic on ports used by
+Redpanda and monitoring tools. Once deployed, you can
+use [our Ansible collection](https://github.com/redpanda-data/redpanda-ansible-collection) to build
+a [Redpanda Cluster](https://docs.redpanda.com/docs/home/).
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| aws | 4.35.0 |
-| local | 2.1.0 |
-| random | 3.1.0 |
+| Name   | Version |
+|--------|---------|
+| aws    | 4.35.0  |
+| local  | 2.1.0   |
+| random | 3.1.0   |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| aws | 4.35.0 |
-| local | 2.1.0 |
-| random | 3.1.0 |
+| Name   | Version |
+|--------|---------|
+| aws    | 4.35.0  |
+| local  | 2.1.0   |
+| random | 3.1.0   |
 
 ## Variables
 
-| Variable Name | Variable Type | Variable Description |
-|---|---|---|
-| aws_region | string | The AWS region to deploy the infrastructure on |
-| availability_zone | list(string) | The AWS AZ to deploy the infrastructure on |
-| clients | number | Number of client hosts |
-| client_distro | string | Linux distribution to use for clients |
-| client_instance_type | string | Default client instance type to create |
-| deployment_prefix | string | The prefix for the instance name (defaults to {random uuid}-{timestamp}) |
-| distro | string | The default distribution to base the cluster on |
-| enable_monitoring | bool | Setup a prometheus/grafana instance |
-| ec2_ebs_device_names | list(string) | Device names for EBS volumes |
-| ec2_ebs_volume_count | number | Number of EBS volumes to attach to each Redpanda node |
-| ec2_ebs_volume_iops | number | IOPs for GP3 Volumes |
-| ec2_ebs_volume_size | number | Size of each EBS volume |
-| ec2_ebs_volume_throughput | number | Throughput per volume in MiB |
-| ec2_ebs_volume_type | string | EBS Volume Type (gp3 recommended for performance) |
-| ha | bool | Whether to use placement groups to create an HA topology |
-| instance_type | string | Default redpanda instance type to create |
-| machine_architecture | string | Architecture used for selecting the AMI - change this if using ARM based instances |
-| nodes | number | The number of nodes to deploy |
-| prometheus_instance_type | string | Instant type of the prometheus/grafana node |
-| cluster_ami | string | AMI for Redpanda broker nodes (if not set, will select based on the distro variable |
-| prometheus_ami | string | AMI for prometheus nodes (if not set, will select based on the distro variable |
-| client_ami | string | AMI for Redpanda client nodes (if not set, will select based on the distro variable |
-| public_key_path | string | The public key used to ssh to the hosts |
-| distro_ssh_user | map(string) | The default user used by the AWS AMIs |
-| tiered_storage_enabled | bool | Enables or disables tiered storage |
-| private_key_path | string | The contents of an SSH key to use for the connection. These can be loaded from a file on disk using the file function. This takes preference over password if provided. |
-| security_groups_client | list(string) | Any additional security groups to attach to the client nodes |
-| security_groups_prometheus | list(string) | Any additional security groups to attach to the prometheus nodes |
-| security_groups_redpanda | list(string) | Any additional security groups to attach to the Redpanda nodes |
-| subnet_id | string | The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id |
-| tags | map(string) | A map of key value pairs passed through to AWS tags on resources |
-| vpc_id | string | The ID of the VPC to deploy the instances. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided. |
-| cloud_provider | string | the short, lower case form of the cloud provider |
-| allow_force_destroy | bool | DANGER: Enabling this option will delete your data in Tiered Storage when terraform destroy is run.
-| associate_public_ip_addr | bool | Allows enabling public IPs when using a custom VPC rather than the default |
-| ingress_rules | map(object) | Map of ingress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_block` (list(string)), `self` (bool) |
-| egress_rules | map(object) | Map of egress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_blocks` (list(string)), `self` (bool) |
-| hosts_file_path | string | Path to the desired location of the Ansible hosts file, must NOT have trailing / |
-| hosts_file_name | string | Name of the Ansible hosts file |
+| Variable Name              | Variable Type | Variable Description                                                                                                                                                                                                        |
+|----------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| aws_region                 | string        | The AWS region to deploy the infrastructure on                                                                                                                                                                              |
+| availability_zone          | list(string)  | The AWS AZ to deploy the infrastructure on                                                                                                                                                                                  |
+| clients                    | number        | Number of client hosts                                                                                                                                                                                                      |
+| client_distro              | string        | Linux distribution to use for clients                                                                                                                                                                                       |
+| client_instance_type       | string        | Default client instance type to create                                                                                                                                                                                      |
+| deployment_prefix          | string        | The prefix for the instance name (defaults to {random uuid}-{timestamp})                                                                                                                                                    |
+| distro                     | string        | The default distribution to base the cluster on                                                                                                                                                                             |
+| enable_monitoring          | bool          | Setup a prometheus/grafana instance                                                                                                                                                                                         |
+| ec2_ebs_device_names       | list(string)  | Device names for EBS volumes                                                                                                                                                                                                |
+| ec2_ebs_volume_count       | number        | Number of EBS volumes to attach to each Redpanda node                                                                                                                                                                       |
+| ec2_ebs_volume_iops        | number        | IOPs for GP3 Volumes                                                                                                                                                                                                        |
+| ec2_ebs_volume_size        | number        | Size of each EBS volume                                                                                                                                                                                                     |
+| ec2_ebs_volume_throughput  | number        | Throughput per volume in MiB                                                                                                                                                                                                |
+| ec2_ebs_volume_type        | string        | EBS Volume Type (gp3 recommended for performance)                                                                                                                                                                           |
+| ha                         | bool          | Whether to use placement groups to create an HA topology                                                                                                                                                                    |
+| instance_type              | string        | Default redpanda instance type to create                                                                                                                                                                                    |
+| machine_architecture       | string        | Architecture used for selecting the AMI - change this if using ARM based instances                                                                                                                                          |
+| nodes                      | number        | The number of nodes to deploy                                                                                                                                                                                               |
+| prometheus_instance_type   | string        | Instant type of the prometheus/grafana node                                                                                                                                                                                 |
+| cluster_ami                | string        | AMI for Redpanda broker nodes (if not set, will select based on the distro variable                                                                                                                                         |
+| prometheus_ami             | string        | AMI for prometheus nodes (if not set, will select based on the distro variable                                                                                                                                              |
+| client_ami                 | string        | AMI for Redpanda client nodes (if not set, will select based on the distro variable                                                                                                                                         |
+| public_key_path            | string        | The public key used to ssh to the hosts                                                                                                                                                                                     |
+| distro_ssh_user            | map(string)   | The default user used by the AWS AMIs                                                                                                                                                                                       |
+| tiered_storage_enabled     | bool          | Enables or disables tiered storage                                                                                                                                                                                          |
+| private_key_path           | string        | The contents of an SSH key to use for the connection. These can be loaded from a file on disk using the file function. This takes preference over password if provided.                                                     |
+| security_groups_client     | list(string)  | Any additional security groups to attach to the client nodes                                                                                                                                                                |
+| security_groups_prometheus | list(string)  | Any additional security groups to attach to the prometheus nodes                                                                                                                                                            |
+| security_groups_redpanda   | list(string)  | Any additional security groups to attach to the Redpanda nodes                                                                                                                                                              |
+| subnet_id                  | string        | The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id                                                            |
+| tags                       | map(string)   | A map of key value pairs passed through to AWS tags on resources                                                                                                                                                            |
+| vpc_id                     | string        | The ID of the VPC to deploy the instances. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided.                                                                          |
+| cloud_provider             | string        | the short, lower case form of the cloud provider                                                                                                                                                                            |
+| allow_force_destroy        | bool          | DANGER: Enabling this option will delete your data in Tiered Storage when terraform destroy is run.                                                                                                                         
+| associate_public_ip_addr   | bool          | Allows enabling public IPs when using a custom VPC rather than the default                                                                                                                                                  |
+| ingress_rules              | map(object)   | Map of ingress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_block` (list(string)), `self` (bool) |
+| egress_rules               | map(object)   | Map of egress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_blocks` (list(string)), `self` (bool) |
+| hosts_file_path            | string        | Path to the desired location of the Ansible hosts file, must NOT have trailing /                                                                                                                                            |
+| hosts_file_name            | string        | Name of the Ansible hosts file                                                                                                                                                                                              |
 
+## Outputs
 
-## Outputs 
-
-| Output Name | Output Description |
-|---|---|
-| redpanda | A map of public IPs to private IPs for the Redpanda instances. |
-| redpanda_id | A map with instance IDs of the Redpanda instances. |
-| prometheus | A map of public IPs to private IPs for the Prometheus instances. |
-| prometheus_id | A map with instance IDs of the Prometheus instances. |
-| client | A map of public IPs to private IPs for the client instances. |
-| client_id | A map with instance IDs of the client instances. |
-| ssh_user | SSH user name for the specified distribution. |
-| public_key_path | Path to the public SSH key. |
-| node_details | Details of the nodes in the deployment. |
+| Output Name     | Output Description                                               |
+|-----------------|------------------------------------------------------------------|
+| redpanda        | A map of public IPs to private IPs for the Redpanda instances.   |
+| redpanda_id     | A map with instance IDs of the Redpanda instances.               |
+| prometheus      | A map of public IPs to private IPs for the Prometheus instances. |
+| prometheus_id   | A map with instance IDs of the Prometheus instances.             |
+| client          | A map of public IPs to private IPs for the client instances.     |
+| client_id       | A map with instance IDs of the client instances.                 |
+| ssh_user        | SSH user name for the specified distribution.                    |
+| public_key_path | Path to the public SSH key.                                      |
+| node_details    | Details of the nodes in the deployment.                          |
 
 ## Examples
 
-Examples can be found in the examples directory. 
+Examples can be found in the examples directory.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -2,84 +2,14 @@
 
 [![Build status](https://badge.buildkite.com/474f20b5cae84a6213f822e1643d24e76a38d37229e461421b.svg)](https://buildkite.com/redpanda/terraform-aws-redpanda-cluster)
 
-This Terraform module will deploy VMs on AWS EC2, with a security group which allows inbound traffic on ports used by
+This [Terraform module](https://registry.terraform.io/modules/redpanda-data/redpanda-cluster/aws/latest) will deploy VMs
+on AWS EC2, with a security group which allows inbound traffic on ports used by
 Redpanda and monitoring tools. Once deployed, you can
 use [our Ansible collection](https://github.com/redpanda-data/redpanda-ansible-collection) to build
 a [Redpanda Cluster](https://docs.redpanda.com/docs/home/).
 
-## Requirements
-
-| Name   | Version |
-|--------|---------|
-| aws    | 4.35.0  |
-| local  | 2.1.0   |
-| random | 3.1.0   |
-
-## Providers
-
-| Name   | Version |
-|--------|---------|
-| aws    | 4.35.0  |
-| local  | 2.1.0   |
-| random | 3.1.0   |
-
-## Variables
-
-| Variable Name              | Variable Type | Variable Description                                                                                                                                                                                                        |
-|----------------------------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| aws_region                 | string        | The AWS region to deploy the infrastructure on                                                                                                                                                                              |
-| availability_zone          | list(string)  | The AWS AZ to deploy the infrastructure on                                                                                                                                                                                  |
-| clients                    | number        | Number of client hosts                                                                                                                                                                                                      |
-| client_distro              | string        | Linux distribution to use for clients                                                                                                                                                                                       |
-| client_instance_type       | string        | Default client instance type to create                                                                                                                                                                                      |
-| deployment_prefix          | string        | The prefix for the instance name (defaults to {random uuid}-{timestamp})                                                                                                                                                    |
-| distro                     | string        | The default distribution to base the cluster on                                                                                                                                                                             |
-| enable_monitoring          | bool          | Setup a prometheus/grafana instance                                                                                                                                                                                         |
-| ec2_ebs_device_names       | list(string)  | Device names for EBS volumes                                                                                                                                                                                                |
-| ec2_ebs_volume_count       | number        | Number of EBS volumes to attach to each Redpanda node                                                                                                                                                                       |
-| ec2_ebs_volume_iops        | number        | IOPs for GP3 Volumes                                                                                                                                                                                                        |
-| ec2_ebs_volume_size        | number        | Size of each EBS volume                                                                                                                                                                                                     |
-| ec2_ebs_volume_throughput  | number        | Throughput per volume in MiB                                                                                                                                                                                                |
-| ec2_ebs_volume_type        | string        | EBS Volume Type (gp3 recommended for performance)                                                                                                                                                                           |
-| ha                         | bool          | Whether to use placement groups to create an HA topology                                                                                                                                                                    |
-| instance_type              | string        | Default redpanda instance type to create                                                                                                                                                                                    |
-| machine_architecture       | string        | Architecture used for selecting the AMI - change this if using ARM based instances                                                                                                                                          |
-| nodes                      | number        | The number of nodes to deploy                                                                                                                                                                                               |
-| prometheus_instance_type   | string        | Instant type of the prometheus/grafana node                                                                                                                                                                                 |
-| cluster_ami                | string        | AMI for Redpanda broker nodes (if not set, will select based on the distro variable                                                                                                                                         |
-| prometheus_ami             | string        | AMI for prometheus nodes (if not set, will select based on the distro variable                                                                                                                                              |
-| client_ami                 | string        | AMI for Redpanda client nodes (if not set, will select based on the distro variable                                                                                                                                         |
-| public_key_path            | string        | The public key used to ssh to the hosts                                                                                                                                                                                     |
-| distro_ssh_user            | map(string)   | The default user used by the AWS AMIs                                                                                                                                                                                       |
-| tiered_storage_enabled     | bool          | Enables or disables tiered storage                                                                                                                                                                                          |
-| private_key_path           | string        | The contents of an SSH key to use for the connection. These can be loaded from a file on disk using the file function. This takes preference over password if provided.                                                     |
-| security_groups_client     | list(string)  | Any additional security groups to attach to the client nodes                                                                                                                                                                |
-| security_groups_prometheus | list(string)  | Any additional security groups to attach to the prometheus nodes                                                                                                                                                            |
-| security_groups_redpanda   | list(string)  | Any additional security groups to attach to the Redpanda nodes                                                                                                                                                              |
-| subnet_id                  | string        | The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id                                                            |
-| tags                       | map(string)   | A map of key value pairs passed through to AWS tags on resources                                                                                                                                                            |
-| vpc_id                     | string        | The ID of the VPC to deploy the instances. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided.                                                                          |
-| cloud_provider             | string        | the short, lower case form of the cloud provider                                                                                                                                                                            |
-| allow_force_destroy        | bool          | DANGER: Enabling this option will delete your data in Tiered Storage when terraform destroy is run.                                                                                                                         
-| associate_public_ip_addr   | bool          | Allows enabling public IPs when using a custom VPC rather than the default                                                                                                                                                  |
-| ingress_rules              | map(object)   | Map of ingress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_block` (list(string)), `self` (bool) |
-| egress_rules               | map(object)   | Map of egress rules to create. Each rule has the following properties: `description` (string), `from_port` (number), `to_port` (number), `protocol` (string), `enabled` (bool), `cidr_blocks` (list(string)), `self` (bool) |
-| hosts_file_path            | string        | Path to the desired location of the Ansible hosts file, must NOT have trailing /                                                                                                                                            |
-| hosts_file_name            | string        | Name of the Ansible hosts file                                                                                                                                                                                              |
-
-## Outputs
-
-| Output Name     | Output Description                                               |
-|-----------------|------------------------------------------------------------------|
-| redpanda        | A map of public IPs to private IPs for the Redpanda instances.   |
-| redpanda_id     | A map with instance IDs of the Redpanda instances.               |
-| prometheus      | A map of public IPs to private IPs for the Prometheus instances. |
-| prometheus_id   | A map with instance IDs of the Prometheus instances.             |
-| client          | A map of public IPs to private IPs for the client instances.     |
-| client_id       | A map with instance IDs of the client instances.                 |
-| ssh_user        | SSH user name for the specified distribution.                    |
-| public_key_path | Path to the public SSH key.                                      |
-| node_details    | Details of the nodes in the deployment.                          |
+More information about building a Redpanda cluster can be viewed on
+our [docs page](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/manual/).
 
 ## Examples
 
@@ -87,15 +17,7 @@ Examples can be found in the examples directory.
 
 ## Test
 
-## Requirements
-
-You must have Go installed in order to run infrastructure tests.
-
-| Name      | Version |
-|-----------|---------|
-| go        | >1.18   |
-| terraform | >1.0.0  |
-
-Test the infrastructure with the following command:
-
-`cd tests/ && go test `
+Testing is done by running terraform apply in each of the example directories and verifying that a green apply has
+occurred. In addition
+the [deployment-automation](https://github.com/redpanda-data/deployment-automation) repo uses this module to build
+Redpanda clusters.

--- a/ansible-hosts-file.tf
+++ b/ansible-hosts-file.tf
@@ -9,8 +9,8 @@ resource "local_file" "hosts_ini" {
     rack                       = var.ha ? aws_instance.broker[*].placement_partition_number : aws_instance.broker[*].availability_zone
     rack_awareness             = var.ha || length(var.availability_zone) > 1
     availability_zone          = aws_instance.broker[*].availability_zone
-    redpanda_public_ips        = aws_instance.broker[*].public_ip
-    redpanda_private_ips       = aws_instance.broker[*].private_ip
+    broker_public_ips          = aws_instance.broker[*].public_ip
+    broker_private_ips         = aws_instance.broker[*].private_ip
     ssh_user                   = var.distro_ssh_user[var.distro]
     tiered_storage_bucket_name = local.tiered_storage_bucket_name
     tiered_storage_enabled     = var.tiered_storage_enabled

--- a/ansible-hosts-file.tf
+++ b/ansible-hosts-file.tf
@@ -1,16 +1,16 @@
 resource "local_file" "hosts_ini" {
-  content =  templatefile("${path.module}/hosts.ini.tpl", {
+  content = templatefile("${path.module}/hosts.ini.tpl", {
     cloud_storage_region       = var.aws_region
     client_public_ips          = aws_instance.client[*].public_ip
     client_private_ips         = aws_instance.client[*].private_ip
     enable_monitoring          = var.enable_monitoring
     monitor_public_ip          = var.enable_monitoring ? aws_instance.prometheus[0].public_ip : ""
     monitor_private_ip         = var.enable_monitoring ? aws_instance.prometheus[0].private_ip : ""
-    rack                       = var.ha ? aws_instance.redpanda[*].placement_partition_number : aws_instance.redpanda[*].availability_zone
+    rack                       = var.ha ? aws_instance.broker[*].placement_partition_number : aws_instance.broker[*].availability_zone
     rack_awareness             = var.ha || length(var.availability_zone) > 1
-    availability_zone          = aws_instance.redpanda[*].availability_zone
-    redpanda_public_ips        = aws_instance.redpanda[*].public_ip
-    redpanda_private_ips       = aws_instance.redpanda[*].private_ip
+    availability_zone          = aws_instance.broker[*].availability_zone
+    redpanda_public_ips        = aws_instance.broker[*].public_ip
+    redpanda_private_ips       = aws_instance.broker[*].private_ip
     ssh_user                   = var.distro_ssh_user[var.distro]
     tiered_storage_bucket_name = local.tiered_storage_bucket_name
     tiered_storage_enabled     = var.tiered_storage_enabled

--- a/client.tf
+++ b/client.tf
@@ -1,9 +1,9 @@
 resource "aws_instance" "client" {
-  count                       = var.clients
+  count                       = var.client_count  * length(var.availability_zone)
   ami                         = coalesce(var.client_ami, data.aws_ami.ami.image_id)
   instance_type               = var.client_instance_type
   key_name                    = aws_key_pair.ssh.key_name
-  subnet_id                   = try(coalesce(var.client_subnet_id, var.redpanda_subnet_id), "")
+  subnet_id                   = try(lookup(local.merged_subnets["client"], var.availability_zone[count.index % length(var.availability_zone)]), "")
   vpc_security_group_ids      = coalesce(var.security_groups_client, [aws_security_group.node_sec_group.id])
   associate_public_ip_address = var.associate_public_ip_addr_client
 

--- a/client.tf
+++ b/client.tf
@@ -3,9 +3,9 @@ resource "aws_instance" "client" {
   ami                         = coalesce(var.client_ami, data.aws_ami.ami.image_id)
   instance_type               = var.client_instance_type
   key_name                    = aws_key_pair.ssh.key_name
-  subnet_id                   = var.subnet_id
-  vpc_security_group_ids      = concat([aws_security_group.node_sec_group.id], var.security_groups_client)
-  associate_public_ip_address = var.associate_public_ip_addr
+  subnet_id                   = try(coalesce(var.client_subnet_id, var.redpanda_subnet_id), "")
+  vpc_security_group_ids      = coalesce(var.security_groups_client, [aws_security_group.node_sec_group.id])
+  associate_public_ip_address = var.associate_public_ip_addr_client
 
   tags = merge(
     local.merged_tags,
@@ -13,12 +13,6 @@ resource "aws_instance" "client" {
       Name = "${local.deployment_id}-client",
     }
   )
-
-  connection {
-    user        = var.distro_ssh_user[var.client_distro]
-    host        = self.public_ip
-    private_key = file(var.private_key_path)
-  }
 
   lifecycle {
     ignore_changes = [ami]

--- a/data.tf
+++ b/data.tf
@@ -14,6 +14,7 @@ data "aws_ami" "ami" {
     name   = "name"
     values = [
       "ubuntu/images/hvm-ssd/ubuntu-*-amd64-server-*",
+      "ubuntu/images/hvm-ssd/ubuntu-*-arm64-server-*",
       "Fedora-Cloud-Base-*.x86_64-hvm-us-west-2-gp2-0",
       "debian-*-amd64-*",
       "debian-*-hvm-x86_64-gp2-*'",

--- a/examples/private-vpc-no-zone/README.md
+++ b/examples/private-vpc-no-zone/README.md
@@ -1,0 +1,7 @@
+This example shows a best practices deployment in which the brokers are isolated in a separate subnet on a non default
+VPC and not allocated public addresses with any external traffic flowing through the internet gateway. The client can be
+configured as a proxy to allow access between users and the brokers, or additional security groups can be added to each
+port in the ingress/egress rulesets.
+
+This does not include a zone or address assignment to hosts, so may not be suitable for production as hosts will have to
+be referred to by IP which will be lost on rebuild. This is mostly included for CI testing. 

--- a/examples/private-vpc-no-zone/main.tf
+++ b/examples/private-vpc-no-zone/main.tf
@@ -96,28 +96,58 @@ module "redpanda-cluster" {
   client_count      = 1
   availability_zone = ["us-west-2a"]
   egress_rules      = {
-    "SSH" = {
-      description     = "Allow outbound to ssh"
-      from_port       = 22
-      to_port         = 22
+    "PROXY" = {
+      description     = "Allow Proxy"
+      from_port       = 3128
+      to_port         = 3128
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = ["0.0.0.0/0"]
+      cidr_blocks     = [aws_subnet.client.cidr_block]
       self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
-    "PING" = {
-      description     = "Allow ICMP"
-      from_port       = -1
-      to_port         = -1
-      protocol        = "icmp"
+    "INTERNAL" = {
+      description     = "Allow intra group traffic"
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
       enabled         = true
-      cidr_blocks     = ["0.0.0.0/0"]
-      self            = null
-      security_groups = [aws_security_group.client_sec_group.id]
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
   }
   ingress_rules = {
+    "PROXY" = {
+      description     = "Allow Proxy"
+      from_port       = 3128
+      to_port         = 3128
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "HTTP" = {
+      description     = "Allow inbound to 80"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "HTTPS" = {
+      description     = "Allow inbound to 443"
+      from_port       = 443
+      to_port         = 443
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
     "SSH" = {
       description     = "Allow inbound to ssh"
       from_port       = 22
@@ -134,8 +164,8 @@ module "redpanda-cluster" {
       to_port         = 9092
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "RPC" = {
@@ -144,8 +174,8 @@ module "redpanda-cluster" {
       to_port         = 33145
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Admin" = {
@@ -154,8 +184,8 @@ module "redpanda-cluster" {
       to_port         = 9644
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Grafana" = {
@@ -164,8 +194,8 @@ module "redpanda-cluster" {
       to_port         = 3000
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "JavaOMB" = {
@@ -174,8 +204,8 @@ module "redpanda-cluster" {
       to_port         = 8080
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Prometheus" = {
@@ -184,8 +214,8 @@ module "redpanda-cluster" {
       to_port         = 9090
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "NodeExporter" = {
@@ -194,8 +224,8 @@ module "redpanda-cluster" {
       to_port         = 9100
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "SchemaRegistry" = {
@@ -204,8 +234,8 @@ module "redpanda-cluster" {
       to_port         = 8081
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "PING" = {
@@ -217,6 +247,16 @@ module "redpanda-cluster" {
       cidr_blocks     = [aws_subnet.client.cidr_block]
       self            = null
       security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "INTERNAL" = {
+      description     = "Allow intra group traffic"
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
   }
 }

--- a/examples/private-vpc-no-zone/main.tf
+++ b/examples/private-vpc-no-zone/main.tf
@@ -1,0 +1,299 @@
+resource "aws_vpc" "test" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = var.tags
+}
+
+resource "aws_subnet" "server" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags              = var.tags
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_subnet" "client" {
+  vpc_id                  = aws_vpc.test.id
+  cidr_block              = "10.0.2.0/24"
+  map_public_ip_on_launch = true
+
+  tags              = var.tags
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = var.tags
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route_table_association" "client" {
+  subnet_id      = aws_subnet.client.id
+  route_table_id = aws_route_table.test.id
+}
+
+resource "aws_route_table_association" "server" {
+  subnet_id      = aws_subnet.server.id
+  route_table_id = aws_route_table.test.id
+}
+
+resource "aws_security_group" "client_sec_group" {
+  name        = "${var.deployment_prefix}-client-sg"
+  description = "client security group"
+  tags        = var.tags
+  vpc_id      = aws_vpc.test.id
+  ingress {
+    description = "Allow outbound to ssh"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "redpanda-cluster" {
+  source                          = "../../"
+  public_key_path                 = var.public_key_path
+  broker_count                    = var.nodes
+  deployment_prefix               = var.deployment_prefix
+  enable_monitoring               = var.enable_monitoring
+  tiered_storage_enabled          = var.tiered_storage_enabled
+  allow_force_destroy             = var.allow_force_destroy
+  vpc_id                          = aws_vpc.test.id
+  distro                          = var.distro
+  hosts_file                      = var.hosts_file
+  tags                            = var.tags
+  associate_public_ip_addr_client = true
+  security_groups_client          = [aws_security_group.client_sec_group.id]
+  subnets                         = {
+    broker = {
+      "us-west-2a" = aws_subnet.server.id
+    }
+    client = {
+      "us-west-2a" = aws_subnet.client.id
+    }
+  }
+  client_count      = 1
+  availability_zone = ["us-west-2a"]
+  egress_rules      = {
+    "SSH" = {
+      description     = "Allow outbound to ssh"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "PING" = {
+      description     = "Allow ICMP"
+      from_port       = -1
+      to_port         = -1
+      protocol        = "icmp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+  }
+  ingress_rules = {
+    "SSH" = {
+      description     = "Allow inbound to ssh"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "Kafka" = {
+      description     = "Allow inbound to access the Redpanda Kafka endpoint"
+      from_port       = 9092
+      to_port         = 9092
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "RPC" = {
+      description     = "Allow security-group only to access Redpanda RPC endpoint for intra-cluster communication"
+      from_port       = 33145
+      to_port         = 33145
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "Admin" = {
+      description     = "Allow anywhere inbound to access Redpanda Admin endpoint"
+      from_port       = 9644
+      to_port         = 9644
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "Grafana" = {
+      description     = "Allow anywhere inbound to access grafana end point for monitoring"
+      from_port       = 3000
+      to_port         = 3000
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "JavaOMB" = {
+      description     = "Allow inbound to access for Open Messaging Benchmark"
+      from_port       = 8080
+      to_port         = 8080
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "Prometheus" = {
+      description     = "Allow inbound to access Prometheus end point for monitoring"
+      from_port       = 9090
+      to_port         = 9090
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "NodeExporter" = {
+      description     = "node_exporter access within the security-group for ansible"
+      from_port       = 9100
+      to_port         = 9100
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "SchemaRegistry" = {
+      description     = "schema_registry access"
+      from_port       = 8081
+      to_port         = 8081
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "PING" = {
+      description     = "Allow ICMP"
+      from_port       = -1
+      to_port         = -1
+      protocol        = "icmp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+  }
+}
+
+variable "public_key_path" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "nodes" {
+  type    = number
+  default = 3
+}
+
+variable "deployment_prefix" {
+  type    = string
+  default = "rp-vpc"
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "tiered_storage_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "allow_force_destroy" {
+  type    = bool
+  default = false
+}
+
+variable "distro" {
+  type    = string
+  default = "ubuntu-focal"
+}
+
+variable "hosts_file" {
+  type    = string
+  default = "hosts.ini"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/examples/private-vpc/README.md
+++ b/examples/private-vpc/README.md
@@ -1,0 +1,8 @@
+This example shows a best practices deployment in which the brokers are isolated in a separate subnet on a non default
+VPC and not allocated public addresses with any external traffic flowing through the internet gateway. The client can be
+configured as a proxy to allow access between users and the brokers, or additional security groups can be added to each
+port in the ingress/egress rulesets.
+
+This is a reasonable starting point for a production deployment but you may want to explore more or less secure options
+depending on the needs of your applications and business -- for example splitting the brokers into a separate VPC or
+making the kafka api more accessible to external applications. 

--- a/examples/private-vpc/main.tf
+++ b/examples/private-vpc/main.tf
@@ -6,7 +6,6 @@ resource "aws_vpc" "test" {
   tags = var.tags
 }
 
-
 resource "aws_route53_zone" "test" {
   name = "devextest.local"
   vpc {
@@ -14,7 +13,6 @@ resource "aws_route53_zone" "test" {
   }
   tags = var.tags
 }
-
 
 resource "aws_subnet" "server" {
   vpc_id     = aws_vpc.test.id
@@ -104,7 +102,7 @@ module "redpanda-cluster" {
   availability_zone               = ["us-west-2a"]
   egress_rules                    = {
     "SSH" = {
-      description     = "Allow oubound to ssh"
+      description     = "Allow outbound to ssh"
       from_port       = 22
       to_port         = 22
       protocol        = "tcp"
@@ -136,7 +134,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Kafka" = {
-      description     = "Allow anywhere inbound to access the Redpanda Kafka endpoint"
+      description     = "Allow inbound to access the Redpanda Kafka endpoint"
       from_port       = 9092
       to_port         = 9092
       protocol        = "tcp"
@@ -176,7 +174,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "JavaOMB" = {
-      description     = "Allow anywhere inbound to access for Open Messaging Benchmark"
+      description     = "Allow inbound to access for Open Messaging Benchmark"
       from_port       = 8080
       to_port         = 8080
       protocol        = "tcp"
@@ -186,7 +184,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Prometheus" = {
-      description     = "Allow anywhere inbound to access Prometheus end point for monitoring"
+      description     = "Allow inbound to access Prometheus end point for monitoring"
       from_port       = 9090
       to_port         = 9090
       protocol        = "tcp"
@@ -206,7 +204,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "SchemaRegistry" = {
-      description     = "schema_registry access for external users"
+      description     = "schema_registry access"
       from_port       = 8081
       to_port         = 8081
       protocol        = "tcp"

--- a/examples/private-vpc/main.tf
+++ b/examples/private-vpc/main.tf
@@ -82,7 +82,7 @@ resource "aws_security_group" "client_sec_group" {
 module "redpanda-cluster" {
   source                          = "../../"
   public_key_path                 = var.public_key_path
-  nodes                           = var.nodes
+  broker_count                    = var.nodes
   deployment_prefix               = var.deployment_prefix
   enable_monitoring               = var.enable_monitoring
   tiered_storage_enabled          = var.tiered_storage_enabled
@@ -94,13 +94,18 @@ module "redpanda-cluster" {
   create_r53_records              = true
   associate_public_ip_addr_client = true
   security_groups_client          = [aws_security_group.client_sec_group.id]
-  prometheus_subnet_id            = aws_subnet.server.id
-  redpanda_subnet_id              = aws_subnet.server.id
-  client_subnet_id                = aws_subnet.client.id
-  zone_id                         = aws_route53_zone.test.id
-  clients                         = 1
-  availability_zone               = ["us-west-2a"]
-  egress_rules                    = {
+  subnets                         = {
+    broker = {
+      "us-west-2a" = aws_subnet.server.id
+    }
+    client = {
+      "us-west-2a" = aws_subnet.client.id
+    }
+  }
+  zone_id           = aws_route53_zone.test.id
+  client_count      = 1
+  availability_zone = ["us-west-2a"]
+  egress_rules      = {
     "SSH" = {
       description     = "Allow outbound to ssh"
       from_port       = 22

--- a/examples/private-vpc/main.tf
+++ b/examples/private-vpc/main.tf
@@ -106,28 +106,58 @@ module "redpanda-cluster" {
   client_count      = 1
   availability_zone = ["us-west-2a"]
   egress_rules      = {
-    "SSH" = {
-      description     = "Allow outbound to ssh"
-      from_port       = 22
-      to_port         = 22
+    "PROXY" = {
+      description     = "Allow Proxy"
+      from_port       = 3128
+      to_port         = 3128
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = ["0.0.0.0/0"]
+      cidr_blocks     = [aws_subnet.client.cidr_block]
       self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
-    "PING" = {
-      description     = "Allow ICMP"
-      from_port       = -1
-      to_port         = -1
-      protocol        = "icmp"
+    "INTERNAL" = {
+      description     = "Allow intra group traffic"
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
       enabled         = true
-      cidr_blocks     = ["0.0.0.0/0"]
-      self            = null
-      security_groups = [aws_security_group.client_sec_group.id]
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
   }
   ingress_rules = {
+    "PROXY" = {
+      description     = "Allow Proxy"
+      from_port       = 3128
+      to_port         = 3128
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "HTTP" = {
+      description     = "Allow inbound to 80"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "HTTPS" = {
+      description     = "Allow inbound to 443"
+      from_port       = 443
+      to_port         = 443
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
+      security_groups = [aws_security_group.client_sec_group.id]
+    }
     "SSH" = {
       description     = "Allow inbound to ssh"
       from_port       = 22
@@ -144,8 +174,8 @@ module "redpanda-cluster" {
       to_port         = 9092
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "RPC" = {
@@ -154,8 +184,8 @@ module "redpanda-cluster" {
       to_port         = 33145
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Admin" = {
@@ -164,8 +194,8 @@ module "redpanda-cluster" {
       to_port         = 9644
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Grafana" = {
@@ -174,8 +204,8 @@ module "redpanda-cluster" {
       to_port         = 3000
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "JavaOMB" = {
@@ -184,8 +214,8 @@ module "redpanda-cluster" {
       to_port         = 8080
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Prometheus" = {
@@ -194,8 +224,8 @@ module "redpanda-cluster" {
       to_port         = 9090
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "NodeExporter" = {
@@ -204,8 +234,8 @@ module "redpanda-cluster" {
       to_port         = 9100
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "SchemaRegistry" = {
@@ -214,8 +244,8 @@ module "redpanda-cluster" {
       to_port         = 8081
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = [aws_subnet.client.cidr_block]
+      self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "PING" = {
@@ -227,6 +257,16 @@ module "redpanda-cluster" {
       cidr_blocks     = [aws_subnet.client.cidr_block]
       self            = null
       security_groups = [aws_security_group.client_sec_group.id]
+    }
+    "INTERNAL" = {
+      description     = "Allow intra group traffic"
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
   }
 }

--- a/examples/private-vpc/main.tf
+++ b/examples/private-vpc/main.tf
@@ -58,6 +58,22 @@ resource "aws_route_table_association" "server" {
   route_table_id = aws_route_table.test.id
 }
 
+resource "aws_vpc_endpoint" "s3_endpoint" {
+  vpc_id          = aws_vpc.test.id
+  service_name    = "com.amazonaws.${var.region}.s3"
+  route_table_ids = [aws_route_table.test.id]
+  policy          = <<POLICY
+{
+  "Statement": [{
+    "Action": "s3:*",
+    "Effect": "Allow",
+    "Resource": "*",
+    "Principal": "*"
+  }]
+}
+POLICY
+}
+
 resource "aws_security_group" "client_sec_group" {
   name        = "${var.deployment_prefix}-client-sg"
   description = "client security group"
@@ -93,6 +109,7 @@ module "redpanda-cluster" {
   tags                            = var.tags
   create_r53_records              = true
   associate_public_ip_addr_client = true
+  prefix_list_ids                 = [aws_vpc_endpoint.s3_endpoint.prefix_list_id]
   security_groups_client          = [aws_security_group.client_sec_group.id]
   subnets                         = {
     broker = {

--- a/examples/private/README.md
+++ b/examples/private/README.md
@@ -1,0 +1,5 @@
+This example contains a cluster that uses the default VPC and subnet. It has custom security group configuration that
+limits access to the brokers to the client node. Additional security groups can be granted access by adding them to the
+ingress/egress security groups list for each port.
+
+While this is a reasonably secure model, the use of the default VPC is not recommended. 

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -19,6 +19,7 @@ resource "aws_security_group" "client_sec_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
 module "redpanda-cluster" {
   source                          = "../../"
   public_key_path                 = var.public_key_path
@@ -58,85 +59,15 @@ module "redpanda-cluster" {
       self            = null
       security_groups = [aws_security_group.client_sec_group.id]
     }
-    "Kafka" = {
-      description     = "Allow inbound to access the Redpanda Kafka endpoint"
-      from_port       = 9092
-      to_port         = 9092
-      protocol        = "tcp"
+    "INTERNAL" = {
+      description     = "Allow intra group traffic"
+      from_port       = 0
+      to_port         = 0
+      protocol        = -1
       enabled         = true
       cidr_blocks     = null
       self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "RPC" = {
-      description     = "Allow security-group only to access Redpanda RPC endpoint for intra-cluster communication"
-      from_port       = 33145
-      to_port         = 33145
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "Admin" = {
-      description     = "Allow inbound to access Redpanda Admin endpoint"
-      from_port       = 9644
-      to_port         = 9644
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "Grafana" = {
-      description     = "Allow inbound to access grafana end point for monitoring"
-      from_port       = 3000
-      to_port         = 3000
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "JavaOMB" = {
-      description     = "Allow inbound to access for Open Messaging Benchmark"
-      from_port       = 8080
-      to_port         = 8080
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "Prometheus" = {
-      description     = "Allow inbound to access Prometheus end point for monitoring"
-      from_port       = 9090
-      to_port         = 9090
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "NodeExporter" = {
-      description     = "node_exporter access within the security-group for ansible"
-      from_port       = 9100
-      to_port         = 9100
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
-    }
-    "SchemaRegistry" = {
-      description     = "schema_registry access for external users"
-      from_port       = 8081
-      to_port         = 8081
-      protocol        = "tcp"
-      enabled         = true
-      cidr_blocks     = null
-      self            = true
-      security_groups = [aws_security_group.client_sec_group.id]
+      security_groups = []
     }
   }
 }

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -59,7 +59,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Kafka" = {
-      description     = "Allow anywhere inbound to access the Redpanda Kafka endpoint"
+      description     = "Allow inbound to access the Redpanda Kafka endpoint"
       from_port       = 9092
       to_port         = 9092
       protocol        = "tcp"
@@ -79,7 +79,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Admin" = {
-      description     = "Allow anywhere inbound to access Redpanda Admin endpoint"
+      description     = "Allow inbound to access Redpanda Admin endpoint"
       from_port       = 9644
       to_port         = 9644
       protocol        = "tcp"
@@ -89,7 +89,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Grafana" = {
-      description     = "Allow anywhere inbound to access grafana end point for monitoring"
+      description     = "Allow inbound to access grafana end point for monitoring"
       from_port       = 3000
       to_port         = 3000
       protocol        = "tcp"
@@ -99,7 +99,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "JavaOMB" = {
-      description     = "Allow anywhere inbound to access for Open Messaging Benchmark"
+      description     = "Allow inbound to access for Open Messaging Benchmark"
       from_port       = 8080
       to_port         = 8080
       protocol        = "tcp"
@@ -109,7 +109,7 @@ module "redpanda-cluster" {
       security_groups = [aws_security_group.client_sec_group.id]
     }
     "Prometheus" = {
-      description     = "Allow anywhere inbound to access Prometheus end point for monitoring"
+      description     = "Allow inbound to access Prometheus end point for monitoring"
       from_port       = 9090
       to_port         = 9090
       protocol        = "tcp"

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "client_sec_group" {
 module "redpanda-cluster" {
   source                          = "../../"
   public_key_path                 = var.public_key_path
-  nodes                           = var.nodes
+  broker_count                    = var.nodes
   deployment_prefix               = var.deployment_prefix
   enable_monitoring               = var.enable_monitoring
   tiered_storage_enabled          = var.tiered_storage_enabled
@@ -30,7 +30,7 @@ module "redpanda-cluster" {
   distro                          = var.distro
   hosts_file                      = var.hosts_file
   tags                            = var.tags
-  clients                         = 1
+  client_count                    = 1
   security_groups_client          = [aws_security_group.client_sec_group.id]
   associate_public_ip_addr        = true
   associate_public_ip_addr_client = true

--- a/examples/public-vpc/README.md
+++ b/examples/public-vpc/README.md
@@ -1,0 +1,3 @@
+This is an insecure model provided for demo purposes and should not be used for production. It builds out a VPC and
+provides very permissive firewall rules to enable testing in your AWS environment. All nodes are on public IPs and
+accessible on all relevant ports. 

--- a/examples/public-vpc/main.tf
+++ b/examples/public-vpc/main.tf
@@ -1,0 +1,130 @@
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+  tags       = var.tags
+}
+
+resource "aws_subnet" "server" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags              = var.tags
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_internet_gateway" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = var.tags
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = aws_vpc.test.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.test.id
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route_table_association" "test" {
+  subnet_id      = aws_subnet.server.id
+  route_table_id = aws_route_table.test.id
+}
+
+
+module "redpanda-cluster" {
+  source                   = "../../"
+  public_key_path          = var.public_key_path
+  nodes                    = var.nodes
+  enable_monitoring        = var.enable_monitoring
+  tiered_storage_enabled   = var.tiered_storage_enabled
+  allow_force_destroy      = var.allow_force_destroy
+  aws_region               = var.region
+  vpc_id                   = aws_vpc.test.id
+  distro                   = var.distro
+  hosts_file               = var.hosts_file
+  tags                     = var.tags
+  availability_zone        = ["us-west-2a"]
+  deployment_prefix        = var.deployment_prefix
+  redpanda_subnet_id       = aws_subnet.server.id
+  associate_public_ip_addr = true
+}
+
+variable "public_key_path" {
+  type    = string
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "nodes" {
+  type    = number
+  default = 3
+}
+
+variable "deployment_prefix" {
+  type    = string
+  default = "rp-public-vpc"
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "tiered_storage_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "allow_force_destroy" {
+  type    = bool
+  default = false
+}
+
+variable "distro" {
+  type    = string
+  default = "ubuntu-focal"
+}
+
+variable "hosts_file" {
+  type    = string
+  default = "hosts.ini"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/examples/public-vpc/main.tf
+++ b/examples/public-vpc/main.tf
@@ -33,7 +33,6 @@ resource "aws_route_table_association" "test" {
   route_table_id = aws_route_table.test.id
 }
 
-
 module "redpanda-cluster" {
   source                   = "../../"
   public_key_path          = var.public_key_path

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,3 @@
+This example depends on the existence of the default VPC and has extremely permissive firewall rules for convenience. It
+does not include support for tiered storage. It is primarily intended for CI testing of this module and is not
+recommended for use even in a demo setting. 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,7 +1,7 @@
 module "simple-example" {
   source                   = "../../"
   clients                  = 1
-  deployment_prefix        = "redpanda-simple"
+  deployment_prefix        = var.deployment_prefix
   private_key_path         = ".ssh/id_rsa"
   associate_public_ip_addr = true
   tags                     = {
@@ -39,4 +39,9 @@ variable "region" {
 
 provider "aws" {
   region = var.region
+}
+
+variable "deployment_prefix" {
+  type    = string
+  default = "rp-simple"
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,6 +1,6 @@
 module "simple-example" {
   source                   = "../../"
-  clients                  = 1
+  client_count             = 1
   deployment_prefix        = var.deployment_prefix
   private_key_path         = ".ssh/id_rsa"
   associate_public_ip_addr = true

--- a/examples/tiered_storage/README.md
+++ b/examples/tiered_storage/README.md
@@ -1,0 +1,3 @@
+This example depends on the existence of the default VPC and has extremely permissive firewall rules for convenience. It
+includes support for tiered storage. It is primarily intended for CI testing of this module and is not recommended
+for use even in a demo setting. 

--- a/examples/tiered_storage/main.tf
+++ b/examples/tiered_storage/main.tf
@@ -1,6 +1,6 @@
 module "tiered-example" {
   source                   = "../../"
-  clients                  = 1
+  client_count             = 1
   deployment_prefix        = var.deployment_prefix
   tiered_storage_enabled   = true
   allow_force_destroy      = true

--- a/examples/tiered_storage/main.tf
+++ b/examples/tiered_storage/main.tf
@@ -1,7 +1,7 @@
 module "tiered-example" {
   source                   = "../../"
   clients                  = 1
-  deployment_prefix        = "redpanda-tiered"
+  deployment_prefix        = var.deployment_prefix
   tiered_storage_enabled   = true
   allow_force_destroy      = true
   private_key_path         = ".ssh/id_rsa"
@@ -9,6 +9,11 @@ module "tiered-example" {
   tags                     = {
     "owner" : "tiered-test"
   }
+}
+
+variable "deployment_prefix" {
+  type    = string
+  default = "rp-tiered"
 }
 
 terraform {

--- a/hosts.ini.tpl
+++ b/hosts.ini.tpl
@@ -1,16 +1,16 @@
 [redpanda]
-%{ for i, ip in redpanda_public_ips ~}
-${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_private_ips[i]}%{ if rack_awareness } rack=${rack[i]}%{ endif }%{ if tiered_storage_enabled } tiered_storage_bucket_name=${tiered_storage_bucket_name} cloud_storage_region=${cloud_storage_region}%{ endif }
+%{ for i, ip in broker_public_ips ~}
+${ ip != "" ? ip : broker_private_ips[i] } ansible_user=${ ssh_user } ansible_become=True private_ip=${broker_private_ips[i]}%{ if rack_awareness } rack=${rack[i]}%{ endif }%{ if tiered_storage_enabled } tiered_storage_bucket_name=${tiered_storage_bucket_name} cloud_storage_region=${cloud_storage_region}%{ endif }
 %{ endfor ~}
 %{ if enable_monitoring }
 
 [monitor]
-${ monitor_public_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip }
+${ monitor_public_ip != "" ? monitor_public_ip : monitor_private_ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${ monitor_private_ip }
 %{ endif }
 
 %{ if length(client_public_ips) > 0 }
 [client]
 %{ for i, ip in client_public_ips ~}
-${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${client_private_ips[i]} id=${i}
+${ ip != "" ? ip : client_private_ips[i] } ansible_user=${ ssh_user } ansible_become=True private_ip=${client_private_ips[i]} id=${i}
 %{ endfor ~}
 %{ endif }

--- a/locals.tf
+++ b/locals.tf
@@ -10,9 +10,9 @@ locals {
     iam_username : trimprefix(data.aws_arn.caller_arn.resource, "user/")
   }
 
-  merged_tags = merge(local.instance_tags, var.tags)
+  merged_tags  = merge(local.instance_tags, var.tags)
   node_details = [
-    for index, instance in aws_instance.redpanda :
+    for index, instance in aws_instance.broker :
     {
       instance_id : instance.id
       public_ip : instance.public_ip

--- a/main.tf
+++ b/main.tf
@@ -2,17 +2,17 @@ resource "random_uuid" "cluster" {}
 
 resource "time_static" "timestamp" {}
 
-resource "aws_instance" "redpanda" {
-  count                       = var.nodes
+resource "aws_instance" "broker" {
+  count                       = var.broker_count * length(var.availability_zone)
   ami                         = coalesce(var.cluster_ami, data.aws_ami.ami.image_id)
-  instance_type               = var.instance_type
+  instance_type               = var.broker_instance_type
   key_name                    = aws_key_pair.ssh.key_name
   iam_instance_profile        = var.tiered_storage_enabled ? aws_iam_instance_profile.redpanda[0].name : null
   placement_group             = var.ha ? aws_placement_group.redpanda-pg[0].id : null
   placement_partition_number  = var.ha ? (count.index % aws_placement_group.redpanda-pg[0].partition_count) + 1 : null
   availability_zone           = var.availability_zone[count.index % length(var.availability_zone)]
-  vpc_security_group_ids      = coalesce(var.security_groups_redpanda, [aws_security_group.node_sec_group.id])
-  subnet_id                   = var.redpanda_subnet_id
+  vpc_security_group_ids      = coalesce(var.security_groups_broker, [aws_security_group.node_sec_group.id])
+  subnet_id                   = try(lookup(local.merged_subnets["broker"], var.availability_zone[count.index % length(var.availability_zone)]), "")
   associate_public_ip_address = var.associate_public_ip_addr
 
   tags = merge(
@@ -35,8 +35,8 @@ resource "aws_instance" "redpanda" {
 }
 
 resource "aws_ebs_volume" "ebs_volume" {
-  count             = var.nodes * var.ec2_ebs_volume_count
-  availability_zone = aws_instance.redpanda[*].availability_zone[count.index]
+  count             = var.broker_count * var.ec2_ebs_volume_count
+  availability_zone = aws_instance.broker[*].availability_zone[count.index]
   size              = var.ec2_ebs_volume_size
   type              = var.ec2_ebs_volume_type
   iops              = var.ec2_ebs_volume_iops
@@ -44,10 +44,10 @@ resource "aws_ebs_volume" "ebs_volume" {
 }
 
 resource "aws_volume_attachment" "volume_attachment" {
-  count       = var.nodes * var.ec2_ebs_volume_count
+  count       = var.broker_count * var.ec2_ebs_volume_count
   volume_id   = aws_ebs_volume.ebs_volume[*].id[count.index]
   device_name = var.ec2_ebs_device_names[count.index]
-  instance_id = aws_instance.redpanda[*].id[count.index]
+  instance_id = aws_instance.broker[*].id[count.index]
 }
 
 resource "aws_key_pair" "ssh" {

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,8 @@ resource "aws_instance" "redpanda" {
   placement_group             = var.ha ? aws_placement_group.redpanda-pg[0].id : null
   placement_partition_number  = var.ha ? (count.index % aws_placement_group.redpanda-pg[0].partition_count) + 1 : null
   availability_zone           = var.availability_zone[count.index % length(var.availability_zone)]
-  vpc_security_group_ids      = concat([aws_security_group.node_sec_group.id], var.security_groups_redpanda)
-  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = coalesce(var.security_groups_redpanda, [aws_security_group.node_sec_group.id])
+  subnet_id                   = var.redpanda_subnet_id
   associate_public_ip_address = var.associate_public_ip_addr
 
   tags = merge(

--- a/network.tf
+++ b/network.tf
@@ -7,23 +7,35 @@ resource "aws_security_group" "node_sec_group" {
   dynamic "ingress" {
     for_each = {for name, details in var.ingress_rules : name => details if details.enabled}
     content {
-      description = ingress.value.description
-      from_port   = ingress.value.from_port
-      to_port     = ingress.value.to_port
-      protocol    = ingress.value.protocol
-      cidr_blocks = ingress.value.cidr_block
-      self        = ingress.value.self
+      description     = ingress.value.description
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      cidr_blocks     = ingress.value.cidr_blocks
+      self            = ingress.value.self
+      security_groups = ingress.value.security_groups
     }
   }
   dynamic "egress" {
     for_each = {for name, details in var.egress_rules : name => details if details.enabled}
     content {
-      description = egress.value.description
-      from_port   = egress.value.from_port
-      to_port     = egress.value.to_port
-      protocol    = egress.value.protocol
-      cidr_blocks = egress.value.cidr_blocks
-      self        = egress.value.self
+      description     = egress.value.description
+      from_port       = egress.value.from_port
+      to_port         = egress.value.to_port
+      protocol        = egress.value.protocol
+      cidr_blocks     = egress.value.cidr_blocks
+      self            = egress.value.self
+      security_groups = egress.value.security_groups
     }
   }
+}
+
+resource "aws_route53_record" "private_record" {
+  count = var.create_r53_records ? var.nodes : 0
+
+  zone_id = var.zone_id
+  name    = random_id.redpanda[count.index].b64_url
+  type    = "A"
+  ttl     = "300"
+  records = [aws_instance.redpanda[count.index].private_ip]
 }

--- a/network.tf
+++ b/network.tf
@@ -31,11 +31,11 @@ resource "aws_security_group" "node_sec_group" {
 }
 
 resource "aws_route53_record" "private_record" {
-  count = var.create_r53_records ? var.nodes : 0
+  count = var.create_r53_records ? var.broker_count : 0
 
   zone_id = var.zone_id
-  name    = random_id.redpanda[count.index].b64_url
+  name    = random_id.broker[count.index].b64_url
   type    = "A"
   ttl     = "300"
-  records = [aws_instance.redpanda[count.index].private_ip]
+  records = [aws_instance.broker[count.index].private_ip]
 }

--- a/network.tf
+++ b/network.tf
@@ -39,3 +39,14 @@ resource "aws_route53_record" "private_record" {
   ttl     = "300"
   records = [aws_instance.broker[count.index].private_ip]
 }
+
+resource "aws_security_group_rule" "egress_s3" {
+  count             = length(var.prefix_list_ids) > 0 ? 1 : 0
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.node_sec_group.id
+
+  prefix_list_ids = var.prefix_list_ids
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
-output "redpanda" {
-  description = "A map of public IPs to private IPs for the Redpanda instances."
+output "broker" {
+  description = "A map of public IPs to private IPs for the Broker instances."
   value       = {
-    for instance in aws_instance.redpanda :
+    for instance in aws_instance.broker :
     instance.public_ip => instance.private_ip...
   }
 }
 
-output "redpanda_id" {
+output "broker_id" {
   description = "A map with instance IDs of the Redpanda instances."
   value       = {
-    for instance in aws_instance.redpanda :
+    for instance in aws_instance.broker :
     "instance_id" => instance.id...
   }
 }
 
-resource "random_id" "redpanda" {
-  count       = length(aws_instance.redpanda[*].id)
+resource "random_id" "broker" {
+  count       = length(aws_instance.broker[*].id)
   byte_length = 5
   keepers     = {
-    instance_id = aws_instance.redpanda[count.index].id
+    instance_id = aws_instance.broker[count.index].id
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "redpanda" {
   description = "A map of public IPs to private IPs for the Redpanda instances."
-  value = {
+  value       = {
     for instance in aws_instance.redpanda :
     instance.public_ip => instance.private_ip...
   }
@@ -8,7 +8,7 @@ output "redpanda" {
 
 output "redpanda_id" {
   description = "A map with instance IDs of the Redpanda instances."
-  value = {
+  value       = {
     for instance in aws_instance.redpanda :
     "instance_id" => instance.id...
   }
@@ -22,16 +22,9 @@ resource "random_id" "redpanda" {
   }
 }
 
-output "redpanda_map" {
-  value = { for i in range(length(aws_instance.redpanda[*].id)) :
-    lower(random_id.redpanda[i].b64_url) => aws_instance.redpanda[i].private_ip
-  }
-  description = "A map of random IDs to public IPs for the Redpanda instances."
-}
-
 output "prometheus" {
   description = "A map of public IPs to private IPs for the Prometheus instances."
-  value = {
+  value       = {
     for instance in aws_instance.prometheus :
     instance.public_ip => instance.private_ip...
   }
@@ -45,17 +38,9 @@ resource "random_id" "prometheus" {
   }
 }
 
-output "prometheus_map" {
-  value = { for i in range(length(aws_instance.prometheus[*].id)) :
-    lower(random_id.prometheus[i].b64_url) => aws_instance.prometheus[i].public_ip
-  }
-  description = "A map of random IDs to public IPs for the Prometheus instances."
-}
-
-
 output "prometheus_id" {
   description = "A map with instance IDs of the Prometheus instances."
-  value = {
+  value       = {
     for instance in aws_instance.prometheus :
     "instance_id" => instance.id...
   }
@@ -63,7 +48,7 @@ output "prometheus_id" {
 
 output "client" {
   description = "A map of public IPs to private IPs for the client instances."
-  value = {
+  value       = {
     for instance in aws_instance.client :
     instance.public_ip => instance.private_ip...
   }
@@ -71,7 +56,7 @@ output "client" {
 
 output "client_id" {
   description = "A map with instance IDs of the client instances."
-  value = {
+  value       = {
     for instance in aws_instance.client :
     "instance_id" => instance.id...
   }
@@ -85,25 +70,17 @@ resource "random_id" "client" {
   }
 }
 
-output "client_map" {
-  value = { for i in range(length(aws_instance.client[*].id)) :
-    lower(random_id.client[i].b64_url) => aws_instance.client[i].public_ip
-  }
-  description = "A map of random IDs to public IPs for the Client instances."
-}
-
-
 output "ssh_user" {
   description = "SSH user name for the specified distribution."
-  value = var.distro_ssh_user[var.distro]
+  value       = var.distro_ssh_user[var.distro]
 }
 
 output "public_key_path" {
   description = "Path to the public SSH key."
-  value = var.public_key_path
+  value       = var.public_key_path
 }
 
 output "node_details" {
   description = "Details of the nodes in the deployment."
-  value = local.node_details
+  value       = local.node_details
 }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -1,9 +1,9 @@
 resource "aws_instance" "prometheus" {
-  count                       = var.enable_monitoring ? 1 : 0
+  count                       = var.enable_monitoring ? 1 * length(var.availability_zone) : 0
   ami                         = coalesce(var.prometheus_ami, data.aws_ami.ami.image_id)
   instance_type               = var.prometheus_instance_type
   key_name                    = aws_key_pair.ssh.key_name
-  subnet_id                   = try(coalesce(var.prometheus_subnet_id, var.redpanda_subnet_id), "")
+  subnet_id                   = try(lookup(local.merged_subnets["monitor"], var.availability_zone[count.index % length(var.availability_zone)]), "")
   vpc_security_group_ids      = coalesce(var.security_groups_prometheus, [aws_security_group.node_sec_group.id])
   associate_public_ip_address = var.associate_public_ip_addr
 

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -3,8 +3,8 @@ resource "aws_instance" "prometheus" {
   ami                         = coalesce(var.prometheus_ami, data.aws_ami.ami.image_id)
   instance_type               = var.prometheus_instance_type
   key_name                    = aws_key_pair.ssh.key_name
-  subnet_id                   = var.subnet_id
-  vpc_security_group_ids      = concat([aws_security_group.node_sec_group.id], var.security_groups_prometheus)
+  subnet_id                   = try(coalesce(var.prometheus_subnet_id, var.redpanda_subnet_id), "")
+  vpc_security_group_ids      = coalesce(var.security_groups_prometheus, [aws_security_group.node_sec_group.id])
   associate_public_ip_address = var.associate_public_ip_addr
 
   tags = merge(

--- a/vars.tf
+++ b/vars.tf
@@ -198,28 +198,23 @@ variable "private_key_path" {
   default     = null
 }
 
+## SG overrides for the default security groups
 variable "security_groups_client" {
   type        = list(string)
   description = "Any additional security groups to attach to the client nodes"
-  default     = []
+  default     = null
 }
 
 variable "security_groups_prometheus" {
   type        = list(string)
   description = "Any additional security groups to attach to the prometheus nodes"
-  default     = []
+  default     = null
 }
 
 variable "security_groups_redpanda" {
   type        = list(string)
   description = "Any additional security groups to attach to the Redpanda nodes"
-  default     = []
-}
-
-variable "subnet_id" {
-  type        = string
-  description = "The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
-  default     = ""
+  default     = null
 }
 
 variable "tags" {
@@ -256,127 +251,175 @@ variable "associate_public_ip_addr" {
 }
 
 variable "ingress_rules" {
-  description = "Map of ingress rules to create"
+  description = "Map of ingress rules to create on the node sec group. if you are using more than one security group it is probably a good idea to create your own properly specified SGs rather than using this field"
   type        = map(object({
-    description = string
-    from_port   = number
-    to_port     = number
-    protocol    = string
-    enabled     = bool
-    cidr_block  = list(string)
-    self        = bool
+    description     = string
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    enabled         = bool
+    cidr_blocks     = list(string)
+    self            = bool
+    security_groups = list(string)
   }))
   default = {
     "SSH" = {
-      description = "Allow inbound to ssh"
-      from_port   = 22
-      to_port     = 22
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow inbound to ssh"
+      from_port       = 22
+      to_port         = 22
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "Kafka" = {
-      description = "Allow anywhere inbound to access the Redpanda Kafka endpoint"
-      from_port   = 9092
-      to_port     = 9092
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow anywhere inbound to access the Redpanda Kafka endpoint"
+      from_port       = 9092
+      to_port         = 9092
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "RPC" = {
-      description = "Allow security-group only to access Redpanda RPC endpoint for intra-cluster communication"
-      from_port   = 33145
-      to_port     = 33145
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = null
-      self        = true
+      description     = "Allow security-group only to access Redpanda RPC endpoint for intra-cluster communication"
+      from_port       = 33145
+      to_port         = 33145
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
     "Admin" = {
-      description = "Allow anywhere inbound to access Redpanda Admin endpoint"
-      from_port   = 9644
-      to_port     = 9644
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow anywhere inbound to access Redpanda Admin endpoint"
+      from_port       = 9644
+      to_port         = 9644
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "Grafana" = {
-      description = "Allow anywhere inbound to access grafana end point for monitoring"
-      from_port   = 3000
-      to_port     = 3000
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow anywhere inbound to access grafana end point for monitoring"
+      from_port       = 3000
+      to_port         = 3000
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "JavaOMB" = {
-      description = "Allow anywhere inbound to access for Open Messaging Benchmark"
-      from_port   = 8080
-      to_port     = 8080
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow anywhere inbound to access for Open Messaging Benchmark"
+      from_port       = 8080
+      to_port         = 8080
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "Prometheus" = {
-      description = "Allow anywhere inbound to access Prometheus end point for monitoring"
-      from_port   = 9090
-      to_port     = 9090
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "Allow anywhere inbound to access Prometheus end point for monitoring"
+      from_port       = 9090
+      to_port         = 9090
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
     "NodeExporter" = {
-      description = "node_exporter access within the security-group for ansible"
-      from_port   = 9100
-      to_port     = 9100
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = null
-      self        = true
+      description     = "node_exporter access within the security-group for ansible"
+      from_port       = 9100
+      to_port         = 9100
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = null
+      self            = true
+      security_groups = []
     }
     "SchemaRegistry" = {
-      description = "schema_registry access for external users"
-      from_port   = 8081
-      to_port     = 8081
-      protocol    = "tcp"
-      enabled     = true
-      cidr_block  = ["0.0.0.0/0"]
-      self        = null
+      description     = "schema_registry access for external users"
+      from_port       = 8081
+      to_port         = 8081
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
     }
   }
 }
 
 variable "egress_rules" {
-  description = "Map of egress rules to create"
+  description = "Map of egress rules to create. if you are using more than one security group it is probably a good idea to create your own properly specified SGs rather than using this field"
   type        = map(object({
-    description = string
-    from_port   = number
-    to_port     = number
-    protocol    = string
-    enabled     = bool
-    cidr_blocks = list(string)
-    self        = bool
+    description     = string
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    enabled         = bool
+    cidr_blocks     = list(string)
+    self            = bool
+    security_groups = list(string)
   }))
   default = {
     "InternetAccess" = {
-      description = "Allow all outbound Internet access"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
-      enabled     = true
-      self        = null
+      description     = "Allow all outbound Internet access"
+      from_port       = 0
+      to_port         = 0
+      protocol        = "-1"
+      cidr_blocks     = ["0.0.0.0/0"]
+      enabled         = true
+      self            = null
+      security_groups = []
     }
   }
 }
 
 variable "hosts_file" {
-  default = "hosts.ini"
+  default     = "hosts.ini"
   description = "path and name for ansible hosts file generated as output of this module"
-  type = string
+  type        = string
+}
+
+variable "zone_id" {
+  default     = ""
+  description = "zone id you want used for records"
+  type        = string
+}
+
+variable "create_r53_records" {
+  default     = false
+  description = "toggle to create route53 records in the supplied zone id"
+  type        = bool
+}
+
+variable "associate_public_ip_addr_client" {
+  default     = true
+  type        = bool
+  description = "Allows enabling public ips for clients when using a custom VPC rather than the default"
+}
+
+variable "client_subnet_id" {
+  type        = string
+  default     = ""
+  description = "Provides a custom subnet for clients"
+}
+
+variable "prometheus_subnet_id" {
+  default     = ""
+  type        = string
+  description = "Provides a custom subnet for the prometheus node"
+}
+
+variable "redpanda_subnet_id" {
+  type        = string
+  description = "The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
+  default     = ""
 }

--- a/vars.tf
+++ b/vars.tf
@@ -323,6 +323,16 @@ variable "ingress_rules" {
       self            = null
       security_groups = []
     }
+    "PandaProxy" = {
+      description     = "Allow anywhere inbound to access for Panda Proxy"
+      from_port       = 8082
+      to_port         = 8082
+      protocol        = "tcp"
+      enabled         = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
+      security_groups = []
+    }
     "Prometheus" = {
       description     = "Allow anywhere inbound to access Prometheus end point for monitoring"
       from_port       = 9090
@@ -440,4 +450,10 @@ locals {
     client  = try(try(merge(var.subnets["broker"], var.subnets["client"]), var.subnets["broker"]), "")
     monitor = try(try(merge(var.subnets["broker"], var.subnets["monitor"]), var.subnets["broker"]), "")
   }
+}
+
+variable "prefix_list_ids" {
+  description = "a list of vpc endpoints (ex s3) that instances should have access to"
+  default     = []
+  type        = list(string)
 }


### PR DESCRIPTION
Before going into the features, I made an important change to the base module that should be considered carefully:

1) SGs are now coalesce rather than concat:

I did this because when attempting to create a private/public split with the original module's concat, the client node was being added to both the private and public SG. This caused numerous issues that disappeared with the change to coalesce. It is still possible to replicate the original functionality by creating your own subnets and specifying them in a list but it isn't a default feature. 

2) subnets are now specified per instance type rather than a single subnet variable

It wasn't possible to specify different subnets for different instance types which made it impossible to specify a public jumpbox + private cluster. As an additional feature, for instances outside of the redpanda broker group it will attempt to use the subnet variable specific to the instance, then the subnet variable specific to the redpanda broker group, then the default subnet. 

*** 

Adds support for two more models as well as examples demoing them that more perfectly replicate likely client network configurations as part of supporting ansible side work on airgap.

The two new models are:

* private brokers without net access accessible to public access jumpbox while using the default vpc still
* same as above, but with created vpc instead of defaults, r53 records, no public ips on the broker

My hope is that this is both more useful for clients -- because these are configs end users are likely to use -- and improves our ability to test in a realistic manner.

As a final note, I tried to include a default sg ingress/egress ruleset that was merged with any user supplied sg ingress/egress rules unless a bool was flipped to specify not to do the merge, but after substantial testing wasn't able to come up with a method that wasn't rejected out of hand by terraform due to type issues and eventually scrapped the idea due to time constraints. I'll try again at a later date since this would be convenient and I'm reasonably sure there's a way to get it done. 
