### PR TITLE
public node exporter by default

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -349,8 +349,8 @@ variable "ingress_rules" {
       to_port         = 9100
       protocol        = "tcp"
       enabled         = true
-      cidr_blocks     = null
-      self            = true
+      cidr_blocks     = ["0.0.0.0/0"]
+      self            = null
       security_groups = []
     }
     "SchemaRegistry" = {


### PR DESCRIPTION
Currently private IP has to be used for scraping 9100 (node exporter endpoint) while public ip can be used for scraping 9644 (admin endpoint). This seems like an overly restrictive default. 