### PR TITLE
Add Fedora 37 support.

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -17,6 +17,7 @@ data "aws_ami" "ami" {
       "ubuntu/images/hvm-ssd/ubuntu-*-arm64-server-*",
       "Fedora-Cloud-Base-*.x86_64-hvm-us-west-2-gp2-0",
       "Fedora-Cloud-Base-*.aarch64-hvm-us-west-2-gp2-0",
+      "Fedora-Cloud-Base-*.aarch64-hvm-us-west-2-standard",
       "debian-*-amd64-*",
       "debian-*-hvm-x86_64-gp2-*'",
       "amzn2-ami-hvm-2.0.*-x86_64-gp2",

--- a/vars.tf
+++ b/vars.tf
@@ -198,7 +198,7 @@ variable "distro_ssh_user" {
     "Fedora-Cloud-Base-34" = "fedora"
     "Fedora-Cloud-Base-35" = "fedora"
     "Fedora-Cloud-Base-36" = "fedora"
-    #"Fedora-Cloud-Base-37" = "fedora"
+    "Fedora-Cloud-Base-37" = "fedora"
     "ubuntu-bionic"        = "ubuntu"
     "ubuntu-focal"         = "ubuntu"
     "ubuntu-hirsute"       = "ubuntu"


### PR DESCRIPTION
This commit adds Fedora37 to the list of ssh_users and add a new name filter for the standard image
that is used for Fedora Cloud Base 36