### PR TITLE
fix: change filter for lookup

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -9,12 +9,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy VPC Public
@@ -24,12 +24,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy VPC Public IS4
@@ -39,12 +39,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy Simple
@@ -54,12 +54,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy Tiered Storage
@@ -69,12 +69,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy Private VPC
@@ -84,12 +84,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
 
   - label: Terraform Apply and Destroy Private VPC No Zone
@@ -99,12 +99,12 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
   - label: Terraform Apply and Destroy Private VPC Connect
     key: apply-destroy-pvt-vpc-connect
@@ -113,10 +113,10 @@ steps:
       - seek-oss/aws-sm#v2.3.2:
           json-to-env:
             - json-key: .
-              secret-id: sdlc/prod/buildkite/devex_gcp_creds_base64
+              secret-id: sdlc/prod/buildkite/terraform_aws_redpanda_cluster
       - docker#v5.4.0:
           image: glrp/atgt:latest
           environment:
-            - DA_AWS_ACCESS_KEY_ID
-            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION

--- a/.buildkite/scripts/apply.sh
+++ b/.buildkite/scripts/apply.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-
-export AWS_ACCESS_KEY_ID=$DA_AWS_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY=$DA_AWS_SECRET_ACCESS_KEY
-
 mkdir -p ~/.ssh
 ssh-keygen -t rsa -b 4096 -C "test@redpanda.com" -N "" -f ~/.ssh/id_rsa <<< y && chmod 0700 ~/.ssh/id_rsa
 

--- a/client.tf
+++ b/client.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "client" {
-  count                       = var.client_count  * length(var.availability_zone)
+  count                       = var.client_count * length(var.availability_zone)
   ami                         = coalesce(var.client_ami, data.aws_ami.ami.image_id)
   instance_type               = var.client_instance_type
   key_name                    = aws_key_pair.ssh.key_name

--- a/data.tf
+++ b/data.tf
@@ -30,15 +30,15 @@ data "aws_ami" "ami" {
     ]
   }
   filter {
-    name = "architecture"
+    name   = "architecture"
     values = [var.machine_architecture]
   }
   filter {
-    name = "name"
+    name   = "name"
     values = ["*${var.distro}*"]
   }
   filter {
-    name = "virtualization-type"
+    name   = "virtualization-type"
     values = ["hvm"]
   }
 

--- a/data.tf
+++ b/data.tf
@@ -9,34 +9,36 @@ data "aws_arn" "caller_arn" {
 
 data "aws_ami" "ami" {
   most_recent = true
-
   filter {
-    name   = "name"
+    name = "name"
     values = [
       "ubuntu/images/hvm-ssd/ubuntu-*-amd64-server-*",
       "ubuntu/images/hvm-ssd/ubuntu-*-arm64-server-*",
-      "Fedora-Cloud-Base-*.x86_64-hvm-us-west-2-gp2-0",
-      "Fedora-Cloud-Base-*.aarch64-hvm-us-west-2-gp2-0",
-      "Fedora-Cloud-Base-*.aarch64-hvm-us-west-2-standard",
+      "Fedora-Cloud-Base-*.x86_64-hvm-${var.aws_region}-gp2-0",
+      "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-gp2-0",
+      "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-standard",
+      "Fedora-Cloud-Base-*.x86_64-hvm-${var.aws_region}-gp3-0",
+      "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-gp3-0",
+      "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-standard",
       "debian-*-amd64-*",
       "debian-*-hvm-x86_64-gp2-*'",
       "amzn2-ami-hvm-2.0.*-x86_64-gp2",
-      "RHEL*HVM-*-x86_64*Hourly2-GP2"
+      "RHEL*HVM-*-x86_64*Hourly2-GP2",
+      "debian-*-hvm-x86_64-gp3-*'",
+      "amzn2-ami-hvm-2.0.*-x86_64-gp3",
+      "RHEL*HVM-*-x86_64*Hourly2-GP3"
     ]
   }
-
   filter {
-    name   = "architecture"
+    name = "architecture"
     values = [var.machine_architecture]
   }
-
   filter {
-    name   = "name"
+    name = "name"
     values = ["*${var.distro}*"]
   }
-
   filter {
-    name   = "virtualization-type"
+    name = "virtualization-type"
     values = ["hvm"]
   }
 

--- a/examples/public-vpc-is4/main.tf
+++ b/examples/public-vpc-is4/main.tf
@@ -58,13 +58,13 @@ module "redpanda-cluster" {
   distro                 = var.distro
   hosts_file             = var.hosts_file
   tags                   = var.tags
-  subnets                = {
+  subnets = {
     broker = {
       "us-west-2a" = aws_subnet.server-a.id
       "us-west-2b" = aws_subnet.server-b.id
     }
   }
-  availability_zone        = ["us-west-2a", "us-west-2b"]
+  availability_zone = ["us-west-2a", "us-west-2b"]
   deployment_prefix        = var.deployment_prefix
   associate_public_ip_addr = true
   machine_architecture     = "arm64"
@@ -105,7 +105,7 @@ variable "allow_force_destroy" {
 
 variable "distro" {
   type    = string
-  default = "Fedora-Cloud-Base-36"
+  default = "Fedora-Cloud-Base-39"
 }
 
 variable "hosts_file" {
@@ -114,7 +114,7 @@ variable "hosts_file" {
 }
 
 variable "tags" {
-  type    = map(string)
+  type = map(string)
   default = {}
 }
 

--- a/examples/simple-fedora/README.md
+++ b/examples/simple-fedora/README.md
@@ -1,0 +1,3 @@
+This example depends on the existence of the default VPC and has extremely permissive firewall rules for convenience. It
+does not include support for tiered storage. It is primarily intended for CI testing of this module and is not
+recommended for use even in a demo setting. 

--- a/examples/simple-fedora/main.tf
+++ b/examples/simple-fedora/main.tf
@@ -7,7 +7,8 @@ module "simple-example" {
   tags = {
     "owner" : "simple-test"
   }
-  distro = "Fedora-Cloud-Base-39"
+  distro     = "Fedora-Cloud-Base-39"
+  aws_region = var.region
 }
 
 terraform {

--- a/examples/simple-fedora/main.tf
+++ b/examples/simple-fedora/main.tf
@@ -1,0 +1,48 @@
+module "simple-example" {
+  source                   = "../../"
+  client_count             = 1
+  deployment_prefix        = var.deployment_prefix
+  private_key_path         = ".ssh/id_rsa"
+  associate_public_ip_addr = true
+  tags = {
+    "owner" : "simple-test"
+  }
+  distro = "Fedora-Cloud-Base-39"
+}
+
+terraform {
+  required_version = ">=0.12"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "deployment_prefix" {
+  type    = string
+  default = "rp-simple"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
     iam_username : trimprefix(data.aws_arn.caller_arn.resource, "user/")
   }
 
-  merged_tags  = merge(local.instance_tags, var.tags)
+  merged_tags = merge(local.instance_tags, var.tags)
   node_details = [
     for index, instance in aws_instance.broker :
     {

--- a/network.tf
+++ b/network.tf
@@ -5,7 +5,7 @@ resource "aws_security_group" "node_sec_group" {
   vpc_id      = var.vpc_id
 
   dynamic "ingress" {
-    for_each = {for name, details in var.ingress_rules : name => details if details.enabled}
+    for_each = { for name, details in var.ingress_rules : name => details if details.enabled }
     content {
       description     = ingress.value.description
       from_port       = ingress.value.from_port
@@ -17,7 +17,7 @@ resource "aws_security_group" "node_sec_group" {
     }
   }
   dynamic "egress" {
-    for_each = {for name, details in var.egress_rules : name => details if details.enabled}
+    for_each = { for name, details in var.egress_rules : name => details if details.enabled }
     content {
       description     = egress.value.description
       from_port       = egress.value.from_port

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "broker" {
   description = "A map of public IPs to private IPs for the Broker instances."
-  value       = {
+  value = {
     for instance in aws_instance.broker :
     instance.public_ip => instance.private_ip...
   }
@@ -8,7 +8,7 @@ output "broker" {
 
 output "broker_id" {
   description = "A map with instance IDs of the Redpanda instances."
-  value       = {
+  value = {
     for instance in aws_instance.broker :
     "instance_id" => instance.id...
   }
@@ -17,14 +17,14 @@ output "broker_id" {
 resource "random_id" "broker" {
   count       = length(aws_instance.broker[*].id)
   byte_length = 5
-  keepers     = {
+  keepers = {
     instance_id = aws_instance.broker[count.index].id
   }
 }
 
 output "prometheus" {
   description = "A map of public IPs to private IPs for the Prometheus instances."
-  value       = {
+  value = {
     for instance in aws_instance.prometheus :
     instance.public_ip => instance.private_ip...
   }
@@ -33,14 +33,14 @@ output "prometheus" {
 resource "random_id" "prometheus" {
   count       = length(aws_instance.prometheus[*].id)
   byte_length = 5
-  keepers     = {
+  keepers = {
     instance_id = aws_instance.prometheus[count.index].id
   }
 }
 
 output "prometheus_id" {
   description = "A map with instance IDs of the Prometheus instances."
-  value       = {
+  value = {
     for instance in aws_instance.prometheus :
     "instance_id" => instance.id...
   }
@@ -48,7 +48,7 @@ output "prometheus_id" {
 
 output "connect" {
   description = "A map of public IPs to private IPs for the Connect instances."
-  value       = {
+  value = {
     for instance in aws_instance.connect :
     instance.public_ip => instance.private_ip...
   }
@@ -56,7 +56,7 @@ output "connect" {
 
 output "connect_id" {
   description = "A map with instance IDs of the Connect instances."
-  value       = {
+  value = {
     for instance in aws_instance.connect :
     "instance_id" => instance.id...
   }
@@ -65,14 +65,14 @@ output "connect_id" {
 resource "random_id" "connect" {
   count       = length(aws_instance.connect[*].id)
   byte_length = 5
-  keepers     = {
+  keepers = {
     instance_id = aws_instance.connect[count.index].id
   }
 }
 
 output "client" {
   description = "A map of public IPs to private IPs for the client instances."
-  value       = {
+  value = {
     for instance in aws_instance.client :
     instance.public_ip => instance.private_ip...
   }
@@ -80,7 +80,7 @@ output "client" {
 
 output "client_id" {
   description = "A map with instance IDs of the client instances."
-  value       = {
+  value = {
     for instance in aws_instance.client :
     "instance_id" => instance.id...
   }
@@ -89,7 +89,7 @@ output "client_id" {
 resource "random_id" "client" {
   count       = length(aws_instance.client[*].id)
   byte_length = 5
-  keepers     = {
+  keepers = {
     instance_id = aws_instance.client[count.index].id
   }
 }

--- a/tiered-storage.tf
+++ b/tiered-storage.tf
@@ -12,11 +12,11 @@ resource "aws_iam_instance_profile" "redpanda" {
 }
 
 resource "aws_iam_policy" "redpanda" {
-  count  = var.tiered_storage_enabled ? 1 : 0
-  name   = local.deployment_id
-  path   = "/"
+  count = var.tiered_storage_enabled ? 1 : 0
+  name  = local.deployment_id
+  path  = "/"
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
         "Effect" : "Allow",
@@ -34,15 +34,15 @@ resource "aws_iam_policy" "redpanda" {
 }
 
 resource "aws_iam_role" "redpanda" {
-  count              = var.tiered_storage_enabled ? 1 : 0
-  name               = local.deployment_id
+  count = var.tiered_storage_enabled ? 1 : 0
+  name  = local.deployment_id
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [
       {
-        Action    = "sts:AssumeRole"
-        Effect    = "Allow"
-        Sid       = ""
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
         Principal = {
           Service = "ec2.amazonaws.com"
         }

--- a/vars.tf
+++ b/vars.tf
@@ -45,7 +45,7 @@ variable "enable_connect" {
 variable "ec2_ebs_device_names" {
   type        = list(string)
   description = "Device names for EBS volumes"
-  default     = [
+  default = [
     "/dev/xvdba",
     "/dev/xvdbb",
     "/dev/xvdbc",
@@ -192,7 +192,7 @@ variable "public_key_path" {
 variable "distro_ssh_user" {
   description = "The default user used by the AWS AMIs"
   type        = map(string)
-  default     = {
+  default = {
     "debian-10"            = "admin"
     "debian-11"            = "admin"
     "Fedora-Cloud-Base-34" = "fedora"
@@ -208,7 +208,7 @@ variable "distro_ssh_user" {
     "ubuntu-kinetic"       = "ubuntu"
     "RHEL-8"               = "ec2-user"
     #"RHEL-9"              = "ec2-user"
-    "amzn2"                = "ec2-user"
+    "amzn2" = "ec2-user"
   }
 }
 
@@ -278,7 +278,7 @@ variable "associate_public_ip_addr" {
 
 variable "ingress_rules" {
   description = "Map of ingress rules to create on the node sec group. if you are using more than one security group it is probably a good idea to create your own properly specified SGs rather than using this field"
-  type        = map(object({
+  type = map(object({
     description     = string
     from_port       = number
     to_port         = number
@@ -434,7 +434,7 @@ variable "ingress_rules" {
 
 variable "egress_rules" {
   description = "Map of egress rules to create. if you are using more than one security group it is probably a good idea to create your own properly specified SGs rather than using this field"
-  type        = map(object({
+  type = map(object({
     description     = string
     from_port       = number
     to_port         = number
@@ -485,7 +485,7 @@ variable "associate_public_ip_addr_client" {
 variable "subnets" {
   description = "Map of instance types to AZs to subnet IDs. Broker is the default so if you intend to use the same subnet for broker, client and monitor you can just specify broker. However node counts are also taken into account so even if the maps are merged. If you set for example: client to 0 but have specified broker in 6 subnets you will end up with a client map with 6 entries but 0 built clients"
   type        = map(map(string))
-  default     = {
+  default = {
     broker     = {}
     client     = {}
     prometheus = {}


### PR DESCRIPTION
Fixes an issue with the lookup filter caused by a change in the version of the instances available to AWS. 

I would very much like to get rid of this lookup table but I can't work out a way to do it that doesn't break existing behavior without introducing something worse. 

I will probably just do a breaking change at some point (the fail state for an invalid input is an error in the lookup, no destruction and easily resolved) but not today 😅 