### PR TITLE
fix: debian ami

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -21,10 +21,10 @@ data "aws_ami" "ami" {
       "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-gp3-0",
       "Fedora-Cloud-Base-*.aarch64-hvm-${var.aws_region}-standard",
       "debian-*-amd64-*",
-      "debian-*-hvm-x86_64-gp2-*'",
+      "debian-*-hvm-x86_64-gp2-*",
       "amzn2-ami-hvm-2.0.*-x86_64-gp2",
       "RHEL*HVM-*-x86_64*Hourly2-GP2",
-      "debian-*-hvm-x86_64-gp3-*'",
+      "debian-*-hvm-x86_64-gp3-*",
       "amzn2-ami-hvm-2.0.*-x86_64-gp3",
       "RHEL*HVM-*-x86_64*Hourly2-GP3"
     ]


### PR DESCRIPTION
Removes erroneous single quote in the ami filter